### PR TITLE
[Criterion] Add support for quicktest.run all

### DIFF
--- a/lua/quicktest/adapters/criterion/util.lua
+++ b/lua/quicktest/adapters/criterion/util.lua
@@ -38,6 +38,7 @@ function M.print_results(result_json, send)
       end
     end
   end
+  send({ type = "stdout", output = "" })
 end
 
 ---Get all error messages


### PR DESCRIPTION
### New
This PR adds support for `quicktest.run_all` in the `criterion` adapter by running all tests from the build directory defined by the user.

### Changed
In order to support this, I semi-reverted my previous change here 6d44ebe94b0807224b8b99bc7bffa52ff6ddbb55
so that all tests are (again) run through `meson test`. It makes no difference to the user, but it makes the adapter more streamlined when it comes to running test and made it straight-forward to support `run_all`.