### PR TITLE
Fix `playwright.is_enabled` to actually call `options.is_enabled`

### DIFF
--- a/lua/quicktest/adapters/playwright/init.lua
+++ b/lua/quicktest/adapters/playwright/init.lua
@@ -308,7 +308,6 @@ M.is_enabled = function(bufnr, type)
       end
     end
     ::matched_pattern::
-    return is_test_file
   else
     is_test_file = vim.endswith(file_path, ".ts")
       or vim.endswith(file_path, ".js")


### PR DESCRIPTION
Don't return if the test-file pattern matches.