### PR TITLE
Add helper function `imports_from_...` for vitest and playwright

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,39 @@ Using Lazy:
 }
 ```
 
+### Languages with multiple adapters
+
+Same languages like Javascript/Typescript support multiple adapters that might match the same 
+test file. Use the `is_enabled` option to control which adapter should be used for the 
+current buffer.
+
+Some adapters like `playwright` and `vitest` provide a helper function to determine whether
+the current buffer imports from a certain package like `@playwright` or `vitest`. Here is a 
+sample configuration for a project with Playwright and vitest tests:
+
+```lua
+local qt = require("quicktest")
+local playwright = require("quicktest.adapters.playwright")
+local vitest = require("quicktest.adapters.vitest")
+
+qt.setup({
+  adapters = {
+    vitest({
+      is_enabled = function(bufnr)
+        return vitest.imports_from_vitest(bufnr)
+      end
+    }),
+    playwright({
+      is_enabled = function(bufnr)
+        -- In case you are not using the default `@playwright` package but your own
+        -- wrapper, you can specify the package-name that has to be imported
+        return playwright.imports_from_playwright(bufnr, "my-custom-playwright")
+      end
+    }),
+  },
+})
+```
+
 
 
 ## Screenshots

--- a/lua/quicktest/adapters/playwright/init.lua
+++ b/lua/quicktest/adapters/playwright/init.lua
@@ -323,6 +323,25 @@ M.is_enabled = function(bufnr, type)
   return M.options.is_enabled(bufnr, type, is_test_file)
 end
 
+--- A helper function that uses Treesitter to determine whether the current
+--- buffer imports from the package "@playwright" or the `package` passed in.
+--- Use this together with `is_enabled` to filter non-Playwright tests if
+--- you use this adapter together with other JS/TS adapters like `vitest`.
+---@param bufnr integer
+---@param package string?
+---@return boolean
+M.imports_from_playwright = function(bufnr, package)
+  if package == nil then
+    package = "@playwright"
+  end
+  local expr = [[
+      ((import_statement
+        source: (string) @source (#contains? @source "]] .. package .. [[")
+      ))
+    ]]
+  return ts.matches(expr, bufnr)
+end
+
 --- Adapter options.
 setmetatable(M, {
   __call = function(_, opts)

--- a/lua/quicktest/adapters/vitest/init.lua
+++ b/lua/quicktest/adapters/vitest/init.lua
@@ -359,6 +359,25 @@ M.is_enabled = function(bufnr, type)
   return M.options.is_enabled(bufnr, type, is_test_file)
 end
 
+--- A helper function that uses Treesitter to determine whether the current
+--- buffer imports from the package "vitest" or the `package` passed in.
+--- Use this together with `is_enabled` to filter non-vitest tests if
+--- you use this adapter together with other JS/TS adapters like `playwright`.
+---@param bufnr integer
+---@param package string?
+---@return boolean
+M.imports_from_vitest = function(bufnr, package)
+  if package == nil then
+    package = "vitest"
+  end
+  local expr = [[
+      ((import_statement
+        source: (string) @source (#contains? @source "]] .. package .. [[")
+      ))
+    ]]
+  return ts.matches(expr, bufnr)
+end
+
 --- Adapter options.
 setmetatable(M, {
   ---@param opts GoAdapterOptions

--- a/lua/quicktest/ts.lua
+++ b/lua/quicktest/ts.lua
@@ -32,7 +32,7 @@ end
 --- Return `true` if the expr matches.
 ---@param expr string
 ---@param bufnr integer
----@return boolean 
+---@return boolean
 function M.matches(expr, bufnr)
   local root = get_root_node(bufnr)
   if not root then

--- a/lua/quicktest/ts.lua
+++ b/lua/quicktest/ts.lua
@@ -28,6 +28,24 @@ local function get_root_node(bufnr)
   return tree:root()
 end
 
+--- Test the given Treesitter expression against the given buffer.
+--- Return `true` if the expr matches.
+---@param expr string
+---@param bufnr integer
+---@return boolean 
+function M.matches(expr, bufnr)
+  local root = get_root_node(bufnr)
+  if not root then
+    return false
+  end
+
+  local query = vim.treesitter.query.parse(get_buffer_file_type(bufnr), expr)
+  for x in query:iter_matches(root, bufnr) do
+    return true
+  end
+  return false
+end
+
 function M.get_current_test(expr, bufnr, cursor_pos, search_type)
   local root = get_root_node(bufnr)
   if not root then


### PR DESCRIPTION
I was tempted to add a `util` module with a function `js_imports_from` or even add it to `ts`, but I did not want to pollute things and the helper functions are a) very small (and I am ok with that little code duplication) and b) not used that often imho.