### PR TITLE
[criterion] Adapt JSON traversal to work with later versions of meson

### DIFF
--- a/lua/quicktest/adapters/criterion/util.lua
+++ b/lua/quicktest/adapters/criterion/util.lua
@@ -18,6 +18,13 @@ function M.splitstr(inputstr, sep)
   return t
 end
 
+--- Check if table is empty
+---@param t table
+---@return boolean
+function M.is_table_empty(t)
+  return t == nil or next(t) == nil
+end
+
 ---Prints the test results using the callback provided by the plugin
 ---@param result_json table
 ---@param send fun(data: any)
@@ -77,14 +84,15 @@ end
 function M.get_test_exe_from_buffer(bufnr, builddir)
   local bufname = vim.api.nvim_buf_get_name(bufnr)
   local targets = meson.get_targets(builddir)
+
   for _, target in ipairs(targets) do
-    -- print(vim.inspect(target["target_sources"]))
-    for _, target_source in ipairs(target["target_sources"]) do
-      -- print(vim.inspect(source))
-      for _, source in ipairs(target_source["sources"]) do
-        -- print(vim.inspect(source))
-        if source == bufname then
-          return target["name"]
+    for _, ts in ipairs(target["target_sources"]) do
+      local sources = ts["sources"]
+      if not M.is_table_empty(sources) then
+        for _, src in ipairs(sources) do
+          if src == bufname then
+            return target["name"]
+          end
         end
       end
     end


### PR DESCRIPTION
The criterion adapter uses `meson introspect --targets` to map the currently open buffer with a test executable. The output of this command has changed with later versions of meson which breaks this adapter in its current form traversing the decoded json.

Specifically the `target_sources` entry can contain linker information on newer versions whereas older versions does not include that. The adapter was originally written using meson version 0.64.1 where this issue went unnoticed.

These changes has been tested with meson version 0.64.1 and 1.5.1.

Example output with meson 1.5.1
```bash
[
  {
    "name": "hello",
    "id": "hello@exe",
    "type": "executable",
    "defined_in": "/home/oyvind/hello/meson.build",
    "filename": [
      "/home/oyvind/hello/build/hello"
    ],
    "target_sources": [
      {
        "language": "c",
        "compiler": [
          "cc"
        ],
        "parameters": [
          "-I/home/oyvind/hello/build/hello.p",
          "-I/home/oyvind/hello/build",
          "-I/home/oyvind/hello",
          "-fdiagnostics-color=always",
          "-D_FILE_OFFSET_BITS=64",
          "-Wall",
          "-Winvalid-pch",
          "-Wextra",
          "-Wpedantic",
          "-O0",
          "-g"
        ],
        "sources": [
          "/home/oyvind/hello/hello.c"
        ],
        "generated_sources": [],
        "unity_sources": []
      },
      {
        "linker": [
          "cc"
        ],
        "parameters": [
          "-Wl,--as-needed",
          "-Wl,--no-undefined"
        ]
      }
    ],
    "extra_files": [],
    "subproject": null,
    "dependencies": [],
    "depends": [],
    "win_subsystem": "console",
    "installed": true,
    "install_filename": [
      "/usr/local/bin/hello"
    ]
  }
]
```

Example output with meson 0.64.1
```bash
[
  {
    "name": "hello",
    "id": "hello@exe",
    "type": "executable",
    "defined_in": "/home/oyvind/hello/meson.build",
    "filename": [
      "/home/oyvind/hello/build/hello"
    ],
    "build_by_default": true,
    "target_sources": [
      {
        "language": "c",
        "compiler": [
          "cc"
        ],
        "parameters": [
          "-I/home/oyvind/hello/build/hello.p",
          "-I/home/oyvind/hello/build",
          "-I/home/oyvind/hello",
          "-fdiagnostics-color=always",
          "-D_FILE_OFFSET_BITS=64",
          "-Wall",
          "-Winvalid-pch",
          "-Wextra",
          "-Wpedantic",
          "-O0",
          "-g"
        ],
        "sources": [
          "/home/oyvind/hello/hello.c"
        ],
        "generated_sources": []
      }
    ],
    "extra_files": [],
    "subproject": null,
    "installed": true,
    "install_filename": [
      "/usr/local/bin/hello"
    ]
  }
]
```