### PR TITLE
fix(criterion): nil File Check

### DIFF
--- a/lua/quicktest/adapters/criterion/init.lua
+++ b/lua/quicktest/adapters/criterion/init.lua
@@ -191,6 +191,10 @@ end
 M.is_enabled = function(bufnr)
   local bufname = vim.api.nvim_buf_get_name(bufnr)
   local filename = util.get_filename(bufname)
+  if filename == nil then
+    return false
+  end
+
   return vim.startswith(filename, "test_") and vim.endswith(filename, ".c")
 end
 


### PR DESCRIPTION
Adds nil check on filename. In non-Criterion projects this method errors, causing subsequent configured adapters to not evaluate/reach their `is_enabled` func.