### PR TITLE
fix: `vim.uv` usage, fixed deprecations, annotations

### DIFF
--- a/lua/quicktest.lua
+++ b/lua/quicktest.lua
@@ -1,6 +1,7 @@
 -- main module file
 local module = require("quicktest.module")
 
+---@type QuicktestConfig
 local config = {
   adapters = {},
   default_win_mode = "split",
@@ -19,70 +20,84 @@ local config = {
   },
 }
 
----@class MyModule
+---@class Quicktest
 local M = {}
 
 --- @type QuicktestConfig
 M.config = config
 
----@param args QuicktestConfig?
-M.setup = function(args)
-  M.config = vim.tbl_deep_extend("force", M.config, args or {})
+---@param args? QuicktestConfig
+function M.setup(args)
+  args = args or {}
+  M.config = vim.tbl_deep_extend("force", M.config, args)
 end
 
-M.current_win_mode = function()
+function M.current_win_mode()
   return module.current_win_mode(M.config.default_win_mode)
 end
 
 --- @param mode WinModeWithoutAuto
-M.open_win = function(mode)
+function M.open_win(mode)
   return module.try_open_win(mode)
 end
 
 --- @param mode WinModeWithoutAuto
-M.close_win = function(mode)
+function M.close_win(mode)
   return module.try_close_win(mode)
 end
 
 --- @param mode WinModeWithoutAuto
-M.toggle_win = function(mode)
+function M.toggle_win(mode)
   return module.toggle_win(mode)
 end
 
---- @param mode WinMode?
-M.run_previous = function(mode)
-  return module.run_previous(M.config, mode or "auto")
+--- @param mode? WinMode
+function M.run_previous(mode)
+  mode = mode or "auto"
+  return module.run_previous(M.config, mode)
 end
 
---- @param mode WinMode?
---- @param adapter Adapter?
---- @param opts AdapterRunOpts?
-M.run_line = function(mode, adapter, opts)
-  return module.prepare_and_run(M.config, "line", mode or "auto", adapter or "auto", opts or {})
+--- @param mode? WinMode
+--- @param adapter? Adapter
+--- @param opts? AdapterRunOpts
+function M.run_line(mode, adapter, opts)
+  mode = mode or "auto"
+  adapter = adapter or "auto"
+  opts = opts or {}
+  return module.prepare_and_run(M.config, "line", mode, adapter, opts)
 end
 
---- @param mode WinMode?
---- @param adapter Adapter?
---- @param opts AdapterRunOpts?
-M.run_file = function(mode, adapter, opts)
-  return module.prepare_and_run(M.config, "file", mode or "auto", adapter or "auto", opts or {})
+--- @param mode? WinMode
+--- @param adapter? Adapter
+--- @param opts? AdapterRunOpts
+function M.run_file(mode, adapter, opts)
+  mode = mode or "auto"
+  adapter = adapter or "auto"
+  opts = opts or {}
+  return module.prepare_and_run(M.config, "file", mode, adapter, opts)
 end
 
---- @param mode WinMode?
---- @param adapter Adapter?
---- @param opts AdapterRunOpts?
-M.run_dir = function(mode, adapter, opts)
-  return module.prepare_and_run(M.config, "dir", mode or "auto", adapter or "auto", opts or {})
+--- @param mode? WinMode
+--- @param adapter? Adapter
+--- @param opts? AdapterRunOpts
+function M.run_dir(mode, adapter, opts)
+  mode = mode or "auto"
+  adapter = adapter or "auto"
+  opts = opts or {}
+  return module.prepare_and_run(M.config, "dir", mode, adapter, opts)
 end
 
---- @param mode WinMode?
---- @param adapter Adapter?
---- @param opts AdapterRunOpts?
-M.run_all = function(mode, adapter, opts)
-  return module.prepare_and_run(M.config, "all", mode or "auto", adapter or "auto", opts or {})
+--- @param mode? WinMode
+--- @param adapter? Adapter
+--- @param opts? AdapterRunOpts
+function M.run_all(mode, adapter, opts)
+  mode = mode or "auto"
+  adapter = adapter or "auto"
+  opts = opts or {}
+  return module.prepare_and_run(M.config, "all", mode, adapter, opts)
 end
 
-M.cancel_current_run = function()
+function M.cancel_current_run()
   module.kill_current_run()
 end
 

--- a/lua/quicktest/colored_printer.lua
+++ b/lua/quicktest/colored_printer.lua
@@ -434,7 +434,7 @@ function ColoredPrinter:set_next_lines(lines, buf, lines_count)
     for _, h in ipairs(hl) do
       -- print("[" .. h.start .. "," .. h.end_ .. ")", get_highlight_def(h.group))
 
-      vim.hl.range(buf, -1, h.group, { lines_count -1 + i, h.start }, { lines_count -1 + i, h.end_ })
+      vim.hl.range(buf, -1, h.group, { lines_count - 1 + i, h.start }, { lines_count - 1 + i, h.end_ })
       -- api.nvim_buf_add_highlight(buf, -1, h.group, lines_count - 1 + i, h.start, h.end_)
     end
   end

--- a/lua/quicktest/colored_printer.lua
+++ b/lua/quicktest/colored_printer.lua
@@ -128,8 +128,9 @@ function ColoredPrinter:setup_highlight_groups()
   end
 
   -- Use Normal highlight group directly to ensure proper default colors
-  vim.cmd("highlight default QuicktestAnsiColorDefault guifg=NONE guibg=NONE")
-  api.nvim_set_hl(0, "QuicktestAnsiColorDefault", { link = "Normal" })
+  api.nvim_set_hl(0, "QuicktestAnsiColorDefault", { default = true, fg = "NONE", bg = "NONE" })
+  api.nvim_set_hl(0, "QuicktestAnsiColorDefault", { default = true, link = "Normal" })
+  -- vim.cmd("highlight default QuicktestAnsiColorDefault guifg=NONE guibg=NONE")
   -- vim.cmd("highlight default link QuicktestAnsiColorDefault Normal")
   self.color_groups["default"] = "QuicktestAnsiColorDefault"
 end

--- a/lua/quicktest/fs_utils.lua
+++ b/lua/quicktest/fs_utils.lua
@@ -28,6 +28,7 @@ M.path = (function()
     return path
   end
 
+  ---@return string|false
   local function exists(filename)
     local stat = uv.fs_stat(filename)
     return stat and stat.type or false

--- a/lua/quicktest/module.lua
+++ b/lua/quicktest/module.lua
@@ -289,13 +289,7 @@ function M.run(adapter, params, config, opts)
             end
 
             for i, _ in ipairs(errored_lines) do
-              vim.highlight.range(
-                buf,
-                stderr_ns,
-                "DiagnosticError",
-                { i + lines_count - 2, 0 },
-                { i + lines_count - 2, -1 }
-              )
+              vim.hl.range(buf, stderr_ns, "DiagnosticError", { i + lines_count - 2, 0 }, { i + lines_count - 2, -1 })
             end
 
             print_buf_status(buf, lines_count + new_lines_count)

--- a/lua/quicktest/module.lua
+++ b/lua/quicktest/module.lua
@@ -10,15 +10,20 @@ local p = require("plenary.path")
 local M = {}
 
 ---@alias Adapter string | "auto"
----@alias WinMode 'popup' | 'split' | 'auto'
----@alias WinModeWithoutAuto 'popup' | 'split
+---@alias WinMode "popup" | "split" | "auto"
+---@alias WinModeWithoutAuto "popup" | "split
 
 ---@class AdapterRunOpts
----@field additional_args string[]?
+---@field additional_args? string[]
 
----@alias CmdData {type: 'stdout', raw: string, output: string?, decoded: any} | {type: 'stderr', raw: string, output: string?, decoded: any} | {type: 'exit', code: number}
+---@class CmdData
+---@field type "stdout" | "stderr" | "exit"
+---@field raw string
+---@field output? string
+---@field decoded any
+---@field code? number
 
----@alias RunType 'line' | 'file' | 'dir' | 'all'
+---@alias RunType "line" | "file" | "dir" | "all"
 
 ---@class QuicktestAdapter
 ---@field name string
@@ -27,7 +32,7 @@ local M = {}
 ---@field build_dir_run_params fun(bufnr: integer, cursor_pos: integer[], opts: AdapterRunOpts): any
 ---@field build_all_run_params fun(bufnr: integer, cursor_pos: integer[], opts: AdapterRunOpts): any
 ---@field run fun(params: any, send: fun(data: CmdData)): number
----@field after_run fun(params: any, results: CmdData)?
+---@field after_run nil|fun(params: any, results: CmdData)
 ---@field title fun(params: any): string
 ---@field is_enabled fun(bufnr: number, type: RunType): boolean
 
@@ -36,13 +41,31 @@ local M = {}
 ---@field default_win_mode WinModeWithoutAuto
 ---@field use_builtin_colorizer boolean
 
----@alias JobStatus 'running' | 'finished' | 'canceled'
----@alias CmdJob {id: number, started_at: number, finished_at?: number, pid: number?, status: JobStatus, exit_code?: number}
+---@alias JobStatus "running" | "finished" | "canceled"
+
+---@class CmdJob
+---@field id number
+---@field started_at integer
+---@field finished_at? integer
+---@field pid? number
+---@field status JobStatus
+---@field exit_code? integer
+
+---@class PreviousRun
+---@field type string
+---@field adapter_name string
+---@field bufname string
+---@field cursor_pos integer[]
+
+---@alias PreviousRuns table<string, PreviousRun>
+
 ---@type CmdJob | nil
 local current_job = nil
---- @type {[string]: {type: string, adapter_name: string, bufname: string, cursor_pos: integer[]}} | nil
+
+---@type nil | PreviousRuns
 local previous_run = nil
 
+---@return PreviousRuns
 local function load_previous_run()
   local config_path = p:new(vim.fn.stdpath("data"), "quicktest_previous_runs.json")
 
@@ -60,7 +83,7 @@ end
 
 local function save_previous_run()
   if previous_run then
-    ---@diagnostic disable-next-line: missing-parameter
+    ---@diagnostic disable-next-line:missing-parameter
     a.run(function()
       local config_path = p:new(vim.fn.stdpath("data"), "quicktest_previous_runs.json")
       local current_data = load_previous_run()
@@ -132,23 +155,22 @@ local stderr_ns = vim.api.nvim_create_namespace("quicktest_stderr")
 --- @param opts AdapterRunOpts
 function M.run(adapter, params, config, opts)
   if current_job then
-    if current_job.pid then
-      vim.system({ "kill", tostring(current_job.pid) }):wait()
-      current_job = nil
-    else
+    if not current_job.pid then
       return notify.warn("Already running")
     end
+    vim.system({ "kill", tostring(current_job.pid) }):wait()
+    current_job = nil
   end
 
   --- @param buf integer
   --- @param start integer
-  --- @param finish number
+  --- @param finish integer
   --- @param strict_indexing boolean
   --- @param replacements string[]
   local set_ansi_lines = function(buf, start, finish, strict_indexing, replacements)
     local new_lines = {}
     for i, line in ipairs(replacements) do
-      new_lines[i] = string.gsub(line, "[\27\155][][()#;?%d]*[A-PRZcf-ntqry=><~]", "")
+      new_lines[i] = line:gsub("[\27\155][][()#;?%d]*[A-PRZcf-ntqry=><~]", "")
     end
     vim.api.nvim_buf_set_lines(buf, start, finish, strict_indexing, new_lines)
   end
@@ -169,7 +191,7 @@ function M.run(adapter, params, config, opts)
       passedTime = job.finished_at - job.started_at
     end
 
-    local time_display = string.format("%.2f", passedTime / 1000) .. "s"
+    local time_display = ("%.2f"):format(passedTime / 1000) .. "s"
 
     vim.api.nvim_buf_clear_namespace(buf, status_ns, 0, -1)
 
@@ -180,15 +202,17 @@ function M.run(adapter, params, config, opts)
       hl_group = "DiagnosticInfo"
     else
       if job.status == "canceled" then
-        line = "Canceled " .. time_display
+        line = "Canceled "
         hl_group = "DiagnosticWarn"
       elseif job.exit_code ~= 0 then
-        line = "Failed " .. time_display
+        line = "Failed "
         hl_group = "DiagnosticError"
       else
-        line = "Passed " .. time_display
+        line = "Passed "
         hl_group = "DiagnosticOk"
       end
+
+      line = line .. time_display
     end
 
     vim.api.nvim_buf_set_lines(buf, line_count - 1, line_count, false, {
@@ -387,7 +411,7 @@ local function get_adapter_and_params(config, type, adapter_name, current_buffer
 end
 
 --- @param config QuicktestConfig
---- @param type 'line' | 'file' | 'dir' | 'all'
+--- @param type "line" | "file" | "dir" | "all"
 --- @param mode WinMode
 --- @param adapter_name Adapter
 --- @param opts AdapterRunOpts

--- a/lua/quicktest/module.lua
+++ b/lua/quicktest/module.lua
@@ -1,4 +1,5 @@
 local api = vim.api
+local uv = vim.uv or vim.loop
 local notify = require("quicktest.notify")
 local a = require("plenary.async")
 local u = require("plenary.async.util")
@@ -155,7 +156,7 @@ function M.run(adapter, params, config, opts)
   local printer = colorized_printer.new()
 
   --- @type CmdJob
-  local job = { id = math.random(10000000000000000), started_at = vim.uv.now(), status = "running" }
+  local job = { id = math.random(10000000000000000), started_at = uv.now(), status = "running" }
   current_job = job
 
   local is_running = function()
@@ -163,7 +164,7 @@ function M.run(adapter, params, config, opts)
   end
 
   local print_buf_status = function(buf, line_count)
-    local passedTime = vim.loop.now() - job.started_at
+    local passedTime = uv.now() - job.started_at
     if job.finished_at then
       passedTime = job.finished_at - job.started_at
     end
@@ -322,7 +323,7 @@ function M.run(adapter, params, config, opts)
 
       if result.type == "exit" then
         job.exit_code = result.code
-        job.finished_at = vim.uv.now()
+        job.finished_at = uv.now()
         job.status = "finished"
 
         if adapter.after_run then
@@ -486,7 +487,7 @@ function M.kill_current_run()
     vim.system({ "kill", tostring(current_job.pid) }):wait()
 
     job.status = "canceled"
-    job.finished_at = vim.uv.now()
+    job.finished_at = uv.now()
   end
 end
 

--- a/lua/quicktest/notify.lua
+++ b/lua/quicktest/notify.lua
@@ -1,10 +1,10 @@
 local M = {}
 
 ---@param msg string
----@param level number
+---@param level vim.log.levels
 local function notify(msg, level)
   vim.schedule(function()
-    vim.api.nvim_notify(msg, level, { title = "Quicktest" })
+    vim.notify(msg, level, { title = "Quicktest" })
   end)
 end
 


### PR DESCRIPTION
## Changes

- Consistently used `vim.uv`, set `vim.loop` as fallback
- Massively reworked some `colored_printer.lua` sections
- Fixed deprecated calls in `colored_printer.lua` (NEEDS CHECK https://github.com/quolpr/quicktest.nvim/commit/b092736f090038e0aa64baf4c14d5b13a235d0cb)
- Annotations and documentation added/fixed
- Some other minor fixes

> [!NOTE]
> Tests pass successfully